### PR TITLE
Set default value for $cacheDuration

### DIFF
--- a/src/Roumen/Sitemap/Model.php
+++ b/src/Roumen/Sitemap/Model.php
@@ -25,7 +25,7 @@ class Model
      * Cache duration, can be int or timestamp
      * @var Carbon|Datetime|int
      */
-    private $cacheDuration = null;
+    private $cacheDuration = 3600;
 
     /**
      * Populating model variables from configuation file


### PR DESCRIPTION
Changed default value for cache duration from null, to 3600. If someone doesn't create a config and does not set manually cache duration we have a default value which wouldn't throw an exception.
