### PR TITLE
Removing headers when using html format in Sitemap.php

### DIFF
--- a/src/Roumen/Sitemap/Sitemap.php
+++ b/src/Roumen/Sitemap/Sitemap.php
@@ -109,6 +109,9 @@ class Sitemap
     public function render($format = 'xml')
     {
         $data = $this->generate($format);
+        if($format=='html'){
+            return $data['content'];
+        }
         return Response::make($data['content'], 200, $data['headers']);
     }
 


### PR DESCRIPTION
When using html format headers are passed as text in the view. We don't need them.
