### PR TITLE
Sitemapindex variable cleared after storing

### DIFF
--- a/src/Roumen/Sitemap/Sitemap.php
+++ b/src/Roumen/Sitemap/Sitemap.php
@@ -189,7 +189,7 @@ class Sitemap
         File::put($file, $data['content']);
 
         // clear
-        ($format == 'sitemapindex') ? $this->model->sitemap = array() : $this->model->items = array();
+        ($format == 'sitemapindex') ? $this->model->sitemaps = array() : $this->model->items = array();
     }
 
 }


### PR DESCRIPTION
A 's' missing in the model::sitemaps variable so it is not cleared after storing. It is visible when you create more than one sitemapindex.
