### PR TITLE
Multiple file sitemap duplicates data on each file

### DIFF
--- a/src/Roumen/Sitemap/SitemapServiceProvider.php
+++ b/src/Roumen/Sitemap/SitemapServiceProvider.php
@@ -29,7 +29,7 @@ class SitemapServiceProvider extends ServiceProvider {
     public function register()
     {
 
-        $this->app['sitemap'] = $this->app->share(function($app)
+        $this->app->bind('sitemap', function($app)
         {
             $config = $app['config']->get('sitemap::config');
             return new Sitemap($config);


### PR DESCRIPTION
The service provider uses a ‘singleton closure’ approach and shares a single closure (and a single instance of the class) across the whole application.
Since that class provides no way to remove data from its internal storage, each new sitemap file was including the data of all the previous files as well as its own data, leading to gigantic (incorrect) files and huge hardware resource consumption.

To make it work properly, the service provider has to be modified to use classic closure binding instead of a shared closure, so that each resolution from the IoC container creates a new instance of the class.
