### PR TITLE
Correct cache_key for different domains

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -3,6 +3,6 @@
 /* Simple configuration file for Laravel Sitemap package */
 return array(
     'use_cache' => false,
-    'cache_key' => 'Laravel.Sitemap.',
+    'cache_key' => 'Laravel.Sitemap.'.\Request::getHttpHost(),
     'cache_duration' => 3600,
 );


### PR DESCRIPTION
It is required when single Laravel installation works for multiple domains.
