### PR TITLE
Fix imports

### DIFF
--- a/src/Roumen/Sitemap/Sitemap.php
+++ b/src/Roumen/Sitemap/Sitemap.php
@@ -10,11 +10,11 @@ namespace Roumen\Sitemap;
  * @link http://roumen.it/projects/laravel-sitemap
  * @license http://opensource.org/licenses/mit-license.php MIT License
  */
-use Config,
-    Response,
-    View,
-    File,
-    Cache;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Response;
+use Illuminate\Support\Facades\View;
 
 class Sitemap
 {

--- a/src/Roumen/Sitemap/SitemapServiceProvider.php
+++ b/src/Roumen/Sitemap/SitemapServiceProvider.php
@@ -1,8 +1,11 @@
-<?php namespace Roumen\Sitemap;
+<?php
+
+namespace Roumen\Sitemap;
 
 use Illuminate\Support\ServiceProvider;
 
-class SitemapServiceProvider extends ServiceProvider {
+class SitemapServiceProvider extends ServiceProvider
+{
 
     /**
      * Indicates if loading of the provider is deferred.


### PR DESCRIPTION
Packages should never assume that a facade alias is available, so you should use the whole import namespace.