### PR TITLE
Added alias for sitemap for injection

### DIFF
--- a/src/Roumen/Sitemap/SitemapServiceProvider.php
+++ b/src/Roumen/Sitemap/SitemapServiceProvider.php
@@ -46,6 +46,8 @@ class SitemapServiceProvider extends ServiceProvider
 
             return new Sitemap($config);
         });
+        
+        $this->app->alias('sitemap','Roumen\Sitemap\Sitemap');
     }
 
     /**


### PR DESCRIPTION
Added an alias so you are able to inject the sitemap in your constructor. Feels more like laravel. Instead of doing App::make('sitemap').