### PR TITLE
Change publish command to only publish package files

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Then register this service provider with Laravel :
 Publish configuration file (OPTIONAL) :
 
 ```bash
-php artisan vendor:publish
+php artisan vendor:publish --provider="Roumen\Sitemap\SitemapServiceProvider"
 ```
 
 ## Examples


### PR DESCRIPTION
The --provider flag should be used to specify the provider for which we want to publish the files, by doing this we avoid publishing unwanted files from other packages.