### PR TITLE
Fixed Fail to render xml when use sub-directory URI

### DIFF
--- a/src/Roumen/Sitemap/Sitemap.php
+++ b/src/Roumen/Sitemap/Sitemap.php
@@ -348,7 +348,7 @@ class Sitemap
             else if (file_exists(public_path().'/vendor/sitemap/styles/'.$format.'.xsl'))
             {
                 // use the default vendor style
-                $style = '/vendor/sitemap/styles/'.$format.'.xsl';
+                $style = asset('/vendor/sitemap/styles/'.$format.'.xsl');
             }
             else
             {


### PR DESCRIPTION
Fixed Fail to render xml when use sub-directory URI (E.g http://domain.com/public/sitemap) with error

- Failed to load resource: the server responded with a status of 404 (Not Found)