### PR TITLE
bug fixed.

### DIFF
--- a/src/Roumen/Sitemap/Sitemap.php
+++ b/src/Roumen/Sitemap/Sitemap.php
@@ -376,7 +376,7 @@ class Sitemap
         ($format == 'txt' || $format == 'html') ? $fe = $format : $fe = 'xml';
 
         // use custom size limit for sitemaps
-        if ($this->model->getMaxSize() > 0 && count($this->model->getItems()) > $this->model->getMaxSize())
+        if ($this->model->getMaxSize() > 0 && count($this->model->getItems()) >= $this->model->getMaxSize())
         {
             if ($this->model->getUseLimitSize())
             {


### PR DESCRIPTION
hi Roumen,

There is a minor issue in my case. As my expected there are 50,000 articles in each sitemap file.

If I get 50,000 news items from database and my maximum size define as 50,000 in config file.

it will not get into the logic below and not store sitemap file successfully.

`if ($this->model->getMaxSize() > 0 && count($this->model->getItems()) > $this->model->getMaxSize())`

so, I sent a pull request to fix this issue.

Thanks for your useful package to generate sitemap!

