### PR TITLE
Add attribute of last modified time to google-news

### DIFF
--- a/src/views/google-news.php
+++ b/src/views/google-news.php
@@ -4,6 +4,11 @@
 <?php foreach($items as $item) : ?>
   <url>
     <loc><?= $item['loc'] ?></loc>
+    <?php
+      if ($item['lastmod'] !== null) {
+        echo "\t" . '<lastmod>' . date('Y-m-d\TH:i:sP', strtotime($item['lastmod'])) . '</lastmod>' . "\n";
+      }
+    ?>
     <news:news>
       <news:publication>
         <news:name><?= $item['googlenews']['sitename'] ?></news:name>


### PR DESCRIPTION
Hello Roumen,

We need the attribute of last modified time in the sitemap extension of google-news.

Here is an example of Google News Sitemaps:
http://docs.escenic.com/seo-guide/1.1/google_news_sitemaps.html

