### PR TITLE
Add annotation in the type of google-news sitemap

### DIFF
--- a/src/views/google-news.php
+++ b/src/views/google-news.php
@@ -6,7 +6,14 @@
     <loc><?= $item['loc'] ?></loc>
     <?php
       if ($item['lastmod'] !== null) {
-        echo "\t" . '<lastmod>' . date('Y-m-d\TH:i:sP', strtotime($item['lastmod'])) . '</lastmod>' . "\n";
+        echo '<lastmod>' . date('Y-m-d\TH:i:sP', strtotime($item['lastmod'])) . '</lastmod>' . "\n";
+      }
+    ?>
+    <?php
+      if (!empty($item['alternates'])) {
+        foreach ($item['alternates'] as $alternate) {
+          echo '<xhtml:link rel="alternate" media="' . $alternate['media'] . '" href="' . $alternate['url'] . '" />' . "\n";
+        }
       }
     ?>
     <news:news>


### PR DESCRIPTION
Hello Roumen,

We need the annotation in the sitemap extension of google-news for the SEO purpose.

An example of sitemap generated with the type of google-news:

```
<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
  <url>
    <loc>http://news.cnyes.com/Content/20160608/20160608162912000610941.shtml</loc>
    <lastmod>2016-04-14T12:13:32+08:00</lastmod>
    <xhtml:link rel="alternate" media="only screen and (max-width: 640px)" href="http://m.cnyes.com/news/id/2025534" />
    <news:news>
      <news:publication>
        <news:name>鉅亨網</news:name>
        <news:language>zh-tw</news:language>
      </news:publication>
      <news:publication_date>2016-06-08T00:30:24+08:00</news:publication_date>
      <news:title><![CDATA[安泰銀配發現金股利0.6元 連續6年發股利]]></news:title>
  		<news:keywords><![CDATA[]]></news:keywords>
    </news:news>
  </url>
</urlset>
```

Reference:
https://developers.google.com/webmasters/mobile-sites/mobile-seo/separate-urls#annotation-in-the-html